### PR TITLE
New test case

### DIFF
--- a/exercises/acronym/canonical-data.json
+++ b/exercises/acronym/canonical-data.json
@@ -60,6 +60,14 @@
             "phrase": "Something - I made up from thin air"
           },
           "expected": "SIMUFTA"
+        },
+        {
+          "description": "apostrophes",
+          "property": "abbreviate",
+          "input": {
+            "phrase": "Haley's Comet"
+          },
+          "expected": "HC"
         }
       ]
     }


### PR DESCRIPTION
The current solution in the Ruby path doesn't account for apostrophes, it is a more rare case for acronyms but an edge case nonetheless.